### PR TITLE
Potential fix for code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,11 +279,13 @@ function setupGitHubAPIProxy(app, bot) {
       const allowedPaths = ['/repos', '/users', '/issues']; // Example allow-list
       const requestPath = new URL(req.url, 'http://localhost').pathname; // Extract pathname
       
-      if (!allowedPaths.some(path => requestPath.startsWith(path))) {
+      // Normalize and validate the request path
+      const normalizedPath = path.posix.normalize(requestPath); // Prevent path traversal
+      if (!allowedPaths.includes(normalizedPath)) { // Ensure exact match with allow-list
         return res.status(400).json({ error: 'Invalid API path' });
       }
       
-      const githubUrl = `https://api.github.com${requestPath}`;
+      const githubUrl = `https://api.github.com${normalizedPath}`;
       
       // Clone headers, removing host
       const headers = { ...req.headers };


### PR DESCRIPTION
Potential fix for [https://github.com/940smiley/gitty-gitty-git-er/security/code-scanning/5](https://github.com/940smiley/gitty-gitty-git-er/security/code-scanning/5)

To fix the issue, we need to ensure that user input (`req.url`) is properly sanitized and validated before constructing the `githubUrl`. Specifically:
1. Use a stricter validation mechanism to ensure the `requestPath` matches the allowed paths exactly or follows a predefined format.
2. Prevent path traversal attacks by normalizing the `requestPath` and verifying it does not contain malicious patterns (e.g., `../`).
3. Avoid directly using user input in constructing the URL. Instead, map user input to predefined, trusted paths.

The best approach is to use a mapping mechanism where user input selects from a predefined set of valid paths. This eliminates the risk of path traversal and ensures only trusted paths are used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
